### PR TITLE
Add page title sections

### DIFF
--- a/drimgame.html
+++ b/drimgame.html
@@ -38,7 +38,7 @@
 
 </head>
 
-<body id="top" class="ss-preload">
+<body id="top" class="ss-preload project-page">
 
 
     <!-- preloader
@@ -64,6 +64,13 @@
             <span class="s-header__menu-icon"></span>
         </a>
     </header> <!-- end s-header -->
+<section class="page-title">
+    <div class="row">
+        <div class="column large-12">
+            <h1>Deloitte - Corporate Default Dynamics: Sectoral Clustering and Sensitivity to Economic and Environmental Shocks</h1>
+        </div>
+    </div>
+</section>
 
 
 

--- a/lcl.html
+++ b/lcl.html
@@ -31,7 +31,7 @@
 
 </head>
 
-<body id="top" class="ss-preload">
+<body id="top" class="ss-preload project-page">
 
 
     <!-- preloader
@@ -57,6 +57,13 @@
             <span class="s-header__menu-icon"></span>
         </a>
     </header> <!-- end s-header -->
+<section class="page-title">
+    <div class="row">
+        <div class="column large-12">
+            <h1>LCL - Probability of Default scoring modelling</h1>
+        </div>
+    </div>
+</section>
 
 
     <!-- hero


### PR DESCRIPTION
## Summary
- add `project-page` class to body of project pages
- insert a page-title section with the project names for LCL and Deloitte pages

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68551af8410c832f93ac8d800a216b2f